### PR TITLE
Use full path to marc file.

### DIFF
--- a/centralized_metadata/scripts/ftp-ingest-marc-records.sh
+++ b/centralized_metadata/scripts/ftp-ingest-marc-records.sh
@@ -12,7 +12,7 @@ echo get marcive/* | sftp -P $FTP_PORT -i $FTP_ID_PATH -o StrictHostKeyChecking=
 
 ls -la
 
-for file in $(ls); do
+for file in $(find ~+ -type f); do
   echo importing $file
   curl -F "marc_file=@$file" $CM_API_ENDPOINT 
 done


### PR DESCRIPTION
Fixes marc file not uploaded via curl if full path not given.